### PR TITLE
Easier & optimized docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,24 @@
 # Example: docker build . -t dsvw && docker run -p 65412:65412 dsvw
 
-FROM alpine:3.11
+FROM python:3.10-alpine3.18 AS build
 
-RUN apk --no-cache add git python3 py-lxml \
-    && rm -rf /var/cache/apk/*
+RUN apk --no-cache add libxml2-dev libxslt-dev gcc python3 python3-dev py3-pip musl-dev linux-headers
 
-WORKDIR /
-RUN git clone https://github.com/stamparm/DSVW
+RUN python3 -m ensurepip --upgrade && python3 -m pip install pex~=2.1.47
+RUN mkdir /source
+COPY requirements.txt /source/
+RUN pex -r /source/requirements.txt -o /source/pex_wrapper
 
-WORKDIR /DSVW
+FROM python:3.10-alpine3.18 AS final
+
+RUN apk upgrade --no-cache
+WORKDIR /dsvw
+RUN adduser -D dsvw && chown -R dsvw:dsvw /dsvw
+
+COPY dsvw.py .
 RUN sed -i 's/127.0.0.1/0.0.0.0/g' dsvw.py
+COPY --from=build /source /
 
 EXPOSE 65412
-
-CMD ["python3", "dsvw.py"]
+USER dsvw
+CMD ["/dsvw/pex_wrapper", "dsvw.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+
+services:
+  dsvw:
+    build: .
+    expose:
+      - 65412
+    ports:
+      - 65412:65412
+    restart: always


### PR DESCRIPTION
Now docker deployment can be done with only one command:
```
docker-compose up
```
Also the build has been optimized(image size reduced to ~65mb from ~450+mb)